### PR TITLE
Update pom.xml for Tomcat7

### DIFF
--- a/gameoflife-deploy/pom.xml
+++ b/gameoflife-deploy/pom.xml
@@ -54,7 +54,7 @@
     </dependencies>
     <properties>
         <target.version>RELEASE</target.version>
-        <tomcat.manager.url>http://localhost:8888/manager</tomcat.manager.url>
+        <tomcat.manager.url>http://localhost:8888/manager/text</tomcat.manager.url>
         <tomcat.username>admin</tomcat.username>
         <tomcat.password>password</tomcat.password>
     </properties>


### PR DESCRIPTION
Tomcat7 has been out for a while now, since it's already time for Tomcat8, and the old version of this code didn't work with it since in v7 you need to explicitly declare that you're referring to the text version of the manager.
