### PR TITLE
Serenity version 1.8.3 missing from Maven repo so changed it to 1.8.4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ The application is a very simple online version of [Conway's 'game of life'](htt
 
 ## Running the acceptance tests
 
-The acceptance tests are written using Webdriver and [Serenity (formerly Thucydides)](http://thucydides.info). They are designed to run against a running server. Run the jetty instance as described about, then, in another window, go to the gameoflife-acceptance-tests directory and run `mvn clean verify`. The test reports will be generated in the `target/site/thucydides` directory.
+The acceptance tests are written using Webdriver and [Serenity (previously known as 'Thucydides')](http://thucydides.info). They are designed to run against a running server. Run the jetty instance as described about, then, in another window, go to the gameoflife-acceptance-tests directory and run `mvn clean verify`. The test reports will be generated in the `target/site/thucydides` directory.
 
 ## The book
 

--- a/README.markdown
+++ b/README.markdown
@@ -6,11 +6,11 @@ The project is a simple multi-module Maven project. To build the whole project, 
 
 ## Running the game
 
-The application is a very simple online version of [Conway's 'game of life'](http://en.wikipedia.org/wiki/Conway's_Game_of_Life). To see what the game does, run `mvn install` as described above, thengo to the gameoflife-web directory and run `mvn jetty:run`. The application will be running on http://localhost:9090.
+The application is a very simple online version of [Conway's 'game of life'](http://en.wikipedia.org/wiki/Conway's_Game_of_Life). To see what the game does, run `mvn install` as described above, then go to the gameoflife-web directory and run `mvn jetty:run`. The application will be running on http://localhost:9090.
 
 ## Running the acceptance tests
 
-The acceptance tests are written using Webdriver and [Thucydides](http://thucydides.info). They are designed to run against a running server. Run the jetty instance as described about, then, in another window, go to the gameoflife-acceptance-tests directory and run `mvn clean verify`. The test reports will be generated in the `target/site/thucydides` directory.
+The acceptance tests are written using Webdriver and [Serenity (formerly Thucydides)](http://thucydides.info). They are designed to run against a running server. Run the jetty instance as described about, then, in another window, go to the gameoflife-acceptance-tests directory and run `mvn clean verify`. The test reports will be generated in the `target/site/thucydides` directory.
 
 ## The book
 

--- a/gameoflife-core/src/main/java/com/wakaleo/gameoflife/domain/Cell.java
+++ b/gameoflife-core/src/main/java/com/wakaleo/gameoflife/domain/Cell.java
@@ -9,7 +9,7 @@ package com.wakaleo.gameoflife.domain;
  */
 public enum Cell {
 	// Symbols to represent cell status
-    LIVE_CELL("*"), DEAD_CELL(".");
+    LIVE_CELL("@"), DEAD_CELL(":");
 
     private String symbol;
 

--- a/gameoflife-core/src/main/java/com/wakaleo/gameoflife/domain/Cell.java
+++ b/gameoflife-core/src/main/java/com/wakaleo/gameoflife/domain/Cell.java
@@ -9,7 +9,7 @@ package com.wakaleo.gameoflife.domain;
  */
 public enum Cell {
 	// Symbols to represent cell status
-    LIVE_CELL("@"), DEAD_CELL(":");
+    LIVE_CELL("*"), DEAD_CELL(".");
 
     private String symbol;
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <sourceJdk>1.8</sourceJdk>
         <targetJdk>1.8</targetJdk>
         <github.account>wakaleo</github.account>
-        <thucydides.version>1.8.3</thucydides.version>
+        <thucydides.version>1.8.4</thucydides.version>
         <jelastic.context>gameoflife</jelastic.context>
         <jelastic.environment>wakaleo</jelastic.environment>
     </properties>


### PR DESCRIPTION
Build fails to find net.serenity-bdd:serenity-core:jar:1.8.3 in https://repo.maven.apache.org/maven2 because it is missing. 

Build succeeds if the version is incremented to 1.8.4

The error was as follows:
[ERROR] Failed to execute goal net.serenity-bdd.maven.plugins:serenity-maven-plugin:1.8.3:aggregate (serenity-reports) on project gameoflife-web: Execution serenity-reports of goal net.serenity-bdd.maven.plugins:serenity-maven-plugin:1.8.3:aggregate failed: Plugin net.serenity-bdd.maven.plugins:serenity-maven-plugin:1.8.3 or one of its dependencies could not be resolved: Failure to find net.serenity-bdd:serenity-core:jar:1.8.3 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be 