### PR TITLE
Update Jacoco version from 0.7 to 0.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
                                 <plugin>
                                     <groupId>org.jacoco</groupId>
                                     <artifactId>jacoco-maven-plugin</artifactId>
-                                    <version>0.7.2.201409121644</version>
+                                    <version>0.8.2</version>
                                 </plugin>
                                 <plugin>
                                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As Jenkins build was getting failure with below error 
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.5.0.1254:sonar (default-cli) on project gameoflife: You are not using the latest JaCoCo binary format version, please consider upgrading to latest JaCoCo version. -> [Help 1]